### PR TITLE
feat: grid building system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.godot/**/*
+*.cfg
+*.cache
+*.bin

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.godot/**/*
+.godot/
 *.cfg
 *.cache
 *.bin

--- a/scenes/builder/builder.gd
+++ b/scenes/builder/builder.gd
@@ -1,5 +1,3 @@
-@tool
-
 extends Node3D
 
 class_name Builder
@@ -28,7 +26,7 @@ func _initialize_cursor_to_world_raycaster() -> void:
 		cursor_to_world_raycaster = null
 
 # Tile map where buildings will be places
-@export var gridmap: GridMap
+@export var builder_gridmap: BuilderGridmap
 
 # In-Game 3D cursor to preview buildinds to be placed in city
 @export var selector: Node3D
@@ -43,12 +41,8 @@ func _process(delta) -> void:
 	_move_selector_to_cursor_position()
 
 func _move_selector_to_cursor_position() -> void:
-	if _can_move_selector():
-		var new_position = cursor_to_world_raycaster.screen_cursor_position_in_world()
+	var cursor_position_in_world = cursor_to_world_raycaster.screen_cursor_position_in_world()
 
-		if new_position != null:
-			selector.position.x = new_position.x
-			selector.position.z = new_position.z
+	if cursor_position_in_world == null: return
 
-func _can_move_selector() -> bool:
-	return cursor_to_world_raycaster != null and selector != null
+	selector.position = builder_gridmap.world_position_to_tile_center(cursor_position_in_world) * Vector3(1, 0, 1)

--- a/scenes/builder/builder.gd
+++ b/scenes/builder/builder.gd
@@ -44,9 +44,11 @@ func _process(delta) -> void:
 
 func _move_selector_to_cursor_position() -> void:
 	if _can_move_selector():
-		var new_position := cursor_to_world_raycaster.screen_cursor_position_in_world()
-		selector.position.x = new_position.x
-		selector.position.z = new_position.z
+		var new_position = cursor_to_world_raycaster.screen_cursor_position_in_world()
+
+		if new_position != null:
+			selector.position.x = new_position.x
+			selector.position.z = new_position.z
 
 func _can_move_selector() -> bool:
 	return cursor_to_world_raycaster != null and selector != null

--- a/scenes/builder/builder.gd
+++ b/scenes/builder/builder.gd
@@ -1,0 +1,52 @@
+@tool
+
+extends Node3D
+
+class_name Builder
+
+# Game Cursor -> Used for building the city
+@export var cursor: Cursor :
+	set (new_cursor):
+		cursor = new_cursor
+		_initialize_cursor_to_world_raycaster()
+
+# Game Camera
+@export var camera: Camera3D :
+	set (new_camera):
+		camera = new_camera
+		_initialize_cursor_to_world_raycaster()
+
+var plane := Plane(Vector3.UP, Vector3.ZERO)
+
+var cursor_to_world_raycaster : CursorToPerspectiveCameraRaycaster
+
+func _initialize_cursor_to_world_raycaster() -> void:
+	if cursor != null and camera != null:
+		cursor_to_world_raycaster =\
+			CursorToPerspectiveCameraRaycaster.new(camera, plane, cursor)
+	else:
+		cursor_to_world_raycaster = null
+
+# Tile map where buildings will be places
+@export var gridmap: GridMap
+
+# In-Game 3D cursor to preview buildinds to be placed in city
+@export var selector: Node3D
+
+func _ready() -> void:
+	if selector == null : _set_default_selector()
+
+func _set_default_selector() -> void:
+	selector = $GroundTileSelector
+
+func _process(delta) -> void:
+	_move_selector_to_cursor_position()
+
+func _move_selector_to_cursor_position() -> void:
+	if _can_move_selector():
+		var new_position := cursor_to_world_raycaster.screen_cursor_position_in_world()
+		selector.position.x = new_position.x
+		selector.position.z = new_position.z
+
+func _can_move_selector() -> bool:
+	return cursor_to_world_raycaster != null and selector != null

--- a/scenes/builder/builder.tscn
+++ b/scenes/builder/builder.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=4 format=3 uid="uid://cyb8pf1d38500"]
+
+[ext_resource type="Script" path="res://scenes/builder/builder.gd" id="1_ipd0f"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_5njrq"]
+shading_mode = 0
+albedo_color = Color(0, 0, 0, 1)
+
+[sub_resource type="SphereMesh" id="SphereMesh_x2j0n"]
+material = SubResource("StandardMaterial3D_5njrq")
+radius = 0.1
+height = 0.2
+
+[node name="Builder" type="Node3D"]
+script = ExtResource("1_ipd0f")
+
+[node name="GroundTileSelector" type="Node3D" parent="."]
+
+[node name="Pointer" type="MeshInstance3D" parent="GroundTileSelector"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.27, 0)
+cast_shadow = 0
+mesh = SubResource("SphereMesh_x2j0n")

--- a/scenes/builder/builder.tscn
+++ b/scenes/builder/builder.tscn
@@ -2,21 +2,21 @@
 
 [ext_resource type="Script" path="res://scenes/builder/builder.gd" id="1_ipd0f"]
 
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_5njrq"]
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_3vicn"]
 shading_mode = 0
-albedo_color = Color(0, 0, 0, 1)
+albedo_color = Color(0.889043, 2.02149e-06, 0.471187, 1)
 
-[sub_resource type="SphereMesh" id="SphereMesh_x2j0n"]
-material = SubResource("StandardMaterial3D_5njrq")
-radius = 0.1
-height = 0.2
+[sub_resource type="BoxMesh" id="BoxMesh_t52jh"]
+material = SubResource("StandardMaterial3D_3vicn")
+size = Vector3(1, 0, 1)
 
-[node name="Builder" type="Node3D"]
+[node name="Builder" type="Node3D" node_paths=PackedStringArray("selector")]
 script = ExtResource("1_ipd0f")
+selector = NodePath("GroundTileSelector")
 
 [node name="GroundTileSelector" type="Node3D" parent="."]
 
 [node name="Pointer" type="MeshInstance3D" parent="GroundTileSelector"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.27, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.01, 0)
 cast_shadow = 0
-mesh = SubResource("SphereMesh_x2j0n")
+mesh = SubResource("BoxMesh_t52jh")

--- a/scenes/builder_gridmap/builder_gridmap.gd
+++ b/scenes/builder_gridmap/builder_gridmap.gd
@@ -1,0 +1,19 @@
+extends GridMap
+
+class_name BuilderGridmap
+
+func tile_local_center() -> Vector3:
+	return cell_size * 0.5
+
+func world_position_to_tile_coordinates(position: Vector3) -> Vector3:
+	return Vector3(
+		round((position.x - tile_local_center().x) / cell_size.x),
+		round((position.y - tile_local_center().y) / cell_size.y),
+		round((position.z - tile_local_center().z) / cell_size.z)
+	)
+
+func tile_coordinates_to_world_position(tile_coordinates: Vector3) -> Vector3:
+	return (tile_coordinates * cell_size) + tile_local_center()
+
+func world_position_to_tile_center(position: Vector3) -> Vector3:
+	return tile_coordinates_to_world_position(world_position_to_tile_coordinates(position))

--- a/scenes/builder_gridmap/builder_gridmap.tscn
+++ b/scenes/builder_gridmap/builder_gridmap.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://bkhftpvcbxjgx"]
+
+[ext_resource type="Script" path="res://scenes/builder_gridmap/builder_gridmap.gd" id="1_n3gac"]
+
+[node name="BuilderGridmap" type="GridMap"]
+script = ExtResource("1_n3gac")

--- a/scenes/cursor/cursor.gd
+++ b/scenes/cursor/cursor.gd
@@ -1,0 +1,7 @@
+extends Control
+
+# Represents the game cursor
+class_name Cursor
+
+func screen_position() -> Vector2:
+	return get_viewport().get_mouse_position()

--- a/scenes/cursor/cursor.tscn
+++ b/scenes/cursor/cursor.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=3 uid="uid://da8wohpqrl2pd"]
+
+[ext_resource type="Script" path="res://scenes/cursor/cursor.gd" id="1_nv0dg"]
+
+[node name="Cursor" type="Control"]
+layout_mode = 3
+anchors_preset = 0
+script = ExtResource("1_nv0dg")

--- a/scenes/sandbox/Sandbox.tscn
+++ b/scenes/sandbox/Sandbox.tscn
@@ -23,8 +23,9 @@ fov = 40.0
 
 [node name="Environment" parent="." instance=ExtResource("2_wncav")]
 
-[node name="Builder" parent="." node_paths=PackedStringArray("cursor", "camera") instance=ExtResource("3_d52ai")]
+[node name="Builder" parent="." node_paths=PackedStringArray("cursor", "camera", "selector") instance=ExtResource("3_d52ai")]
 cursor = NodePath("../Cursor")
 camera = NodePath("../View/Camera")
+selector = NodePath("GroundTileSelector")
 
 [node name="Cursor" parent="." instance=ExtResource("4_jcbnu")]

--- a/scenes/sandbox/Sandbox.tscn
+++ b/scenes/sandbox/Sandbox.tscn
@@ -1,12 +1,15 @@
-[gd_scene load_steps=3 format=3 uid="uid://bke5aos7scrrr"]
+[gd_scene load_steps=5 format=3 uid="uid://bke5aos7scrrr"]
 
 [ext_resource type="PackedScene" uid="uid://cqjeyuvhnsxcq" path="res://assets/models/banner.glb" id="1_dcksc"]
 [ext_resource type="PackedScene" uid="uid://dq1vvxw3jq3do" path="res://scenes/environment/environment.tscn" id="2_wncav"]
+[ext_resource type="PackedScene" uid="uid://cyb8pf1d38500" path="res://scenes/builder/builder.tscn" id="3_d52ai"]
+[ext_resource type="PackedScene" uid="uid://da8wohpqrl2pd" path="res://scenes/cursor/cursor.tscn" id="4_jcbnu"]
 
 [node name="Sandbox" type="Node3D"]
 
 [node name="banner" parent="." instance=ExtResource("1_dcksc")]
 transform = Transform3D(0.974764, 6.70104e-07, -0.223233, -4.47035e-08, 0.999999, -5.96046e-08, 0.223233, -2.99031e-07, 0.974765, 0.0181224, 1.30385e-08, -0.0524412)
+visible = false
 
 [node name="CSGBox3D" type="CSGBox3D" parent="."]
 size = Vector3(100, 0, 100)
@@ -19,3 +22,9 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 6)
 fov = 40.0
 
 [node name="Environment" parent="." instance=ExtResource("2_wncav")]
+
+[node name="Builder" parent="." node_paths=PackedStringArray("cursor", "camera") instance=ExtResource("3_d52ai")]
+cursor = NodePath("../Cursor")
+camera = NodePath("../View/Camera")
+
+[node name="Cursor" parent="." instance=ExtResource("4_jcbnu")]

--- a/scenes/sandbox/Sandbox.tscn
+++ b/scenes/sandbox/Sandbox.tscn
@@ -1,9 +1,13 @@
-[gd_scene load_steps=5 format=3 uid="uid://bke5aos7scrrr"]
+[gd_scene load_steps=7 format=3 uid="uid://bke5aos7scrrr"]
 
 [ext_resource type="PackedScene" uid="uid://cqjeyuvhnsxcq" path="res://assets/models/banner.glb" id="1_dcksc"]
 [ext_resource type="PackedScene" uid="uid://dq1vvxw3jq3do" path="res://scenes/environment/environment.tscn" id="2_wncav"]
 [ext_resource type="PackedScene" uid="uid://cyb8pf1d38500" path="res://scenes/builder/builder.tscn" id="3_d52ai"]
 [ext_resource type="PackedScene" uid="uid://da8wohpqrl2pd" path="res://scenes/cursor/cursor.tscn" id="4_jcbnu"]
+[ext_resource type="PackedScene" uid="uid://bkhftpvcbxjgx" path="res://scenes/builder_gridmap/builder_gridmap.tscn" id="5_psxm7"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_fvapr"]
+albedo_color = Color(0.18833, 0.47658, 0.517076, 1)
 
 [node name="Sandbox" type="Node3D"]
 
@@ -15,17 +19,25 @@ visible = false
 size = Vector3(100, 0, 100)
 
 [node name="View" type="Node3D" parent="."]
-transform = Transform3D(0.866025, -0.286788, 0.409576, 0, 0.819152, 0.573576, -0.5, -0.496732, 0.709406, 0, 0, 0)
+transform = Transform3D(0.707106, -0.40558, 0.579228, 0, 0.819152, 0.573576, -0.707106, -0.40558, 0.579228, 0, 0, 0)
 
 [node name="Camera" type="Camera3D" parent="View"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 6)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 30)
 fov = 40.0
 
 [node name="Environment" parent="." instance=ExtResource("2_wncav")]
 
-[node name="Builder" parent="." node_paths=PackedStringArray("cursor", "camera", "selector") instance=ExtResource("3_d52ai")]
+[node name="Builder" parent="." node_paths=PackedStringArray("cursor", "camera", "builder_gridmap") instance=ExtResource("3_d52ai")]
 cursor = NodePath("../Cursor")
 camera = NodePath("../View/Camera")
-selector = NodePath("GroundTileSelector")
+builder_gridmap = NodePath("../BuilderGridmap")
 
 [node name="Cursor" parent="." instance=ExtResource("4_jcbnu")]
+
+[node name="CSGBox3D2" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.5, 0.01, 0.5)
+size = Vector3(1, 0, 1)
+material = SubResource("StandardMaterial3D_fvapr")
+
+[node name="BuilderGridmap" parent="." instance=ExtResource("5_psxm7")]
+cell_size = Vector3(1, 1, 1)

--- a/scripts/utils/cursor_to_perspective_camera_raycaster.gd
+++ b/scripts/utils/cursor_to_perspective_camera_raycaster.gd
@@ -21,7 +21,7 @@ func _init(new_view_camera: Camera3D, new_world_plane: Plane, new_game_cursor: C
 	world_plane = new_world_plane
 	game_cursor = new_game_cursor
 
-func screen_cursor_position_in_world() -> Vector3:
+func screen_cursor_position_in_world() -> Variant:
 	return world_plane.intersects_ray(
 		view_camera.project_ray_origin(game_cursor.screen_position()),
 		view_camera.project_ray_normal(game_cursor.screen_position())

--- a/scripts/utils/cursor_to_perspective_camera_raycaster.gd
+++ b/scripts/utils/cursor_to_perspective_camera_raycaster.gd
@@ -1,0 +1,28 @@
+extends Node3D
+
+# Given a 3D camera in perspective mode and a plane,
+# infers the equivalent on-camera position of the mouse
+# in the projected world-environment plane coordinates
+class_name CursorToPerspectiveCameraRaycaster
+
+var view_camera: Camera3D
+var world_plane: Plane
+var game_cursor: Cursor
+
+func _init(new_view_camera: Camera3D, new_world_plane: Plane, new_game_cursor: Cursor) -> void:
+	if new_view_camera.projection != Camera3D.PROJECTION_PERSPECTIVE:
+		push_error("
+			Attempted to instantiate a CursorToPerspectiveCameraRaycaster object
+			with a Camera3D instance configured without a 'perspective' mode
+			projection. This class only supports perspective cameras.
+		")
+
+	view_camera = new_view_camera
+	world_plane = new_world_plane
+	game_cursor = new_game_cursor
+
+func screen_cursor_position_in_world() -> Vector3:
+	return world_plane.intersects_ray(
+		view_camera.project_ray_origin(game_cursor.screen_position()),
+		view_camera.project_ray_normal(game_cursor.screen_position())
+	)


### PR DESCRIPTION
## What

- Adds system to map cursor position on screen to tiles in the world map.
- Defines selector that tracks the cursor position on the screen, indicating where an user can place a building
- Refactors part of the codebase for better consistency with Godot project conventions.

## Why

In order to make possible to create buildings, we need to first let the user indicate where to place which.

This first PR addresses the part concerning to how users can specify the place to build their buildings.

## Results

https://github.com/user-attachments/assets/3d7b6678-71b1-4d30-849c-3e647660bb63

## Checklist

- [X] Add images of the game project.
- [X] Add PR labels for better tracking.
